### PR TITLE
fix: The "open KMUHelper" button inside the admin home does no longer…

### DIFF
--- a/kmuhelper/templates/admin/index.html
+++ b/kmuhelper/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/index.html" %}
-{% load static %}
+{% load static kmuhelper_tags %}
 
 {% block extrastyle %}
     {{ block.super }}
@@ -12,12 +12,7 @@
 
     {% if not app_label %}
         {% if perms.kmuhelper %}
-            <div style="margin-bottom: 32px;">
-                <a href="{% url 'kmuhelper:home' %}" id="kmuhelperbutton">
-                    <i class="fa-fw fa-solid fa-box-open"></i>
-                    <h2>KMUHelper öffnen</h2>
-                </a>
-            </div>
+            {% kmuhelper_open_kmuhelper_button %}
         {% endif %}
     {% endif %}
 

--- a/kmuhelper/templates/admin/kmuhelper/_includes/open_kmuhelper_button.html
+++ b/kmuhelper/templates/admin/kmuhelper/_includes/open_kmuhelper_button.html
@@ -1,0 +1,8 @@
+{% if show %}
+    <div style="margin-bottom: 32px;">
+        <a href="{{ home_url }}" id="kmuhelperbutton">
+            <i class="fa-fw fa-solid fa-box-open"></i>
+            <h2>KMUHelper öffnen</h2>
+        </a>
+    </div>
+{% endif %}

--- a/kmuhelper/templatetags/kmuhelper_tags.py
+++ b/kmuhelper/templatetags/kmuhelper_tags.py
@@ -1,6 +1,6 @@
 from django import template
 from django.apps import apps
-from django.urls import reverse
+from django.urls import reverse, NoReverseMatch
 from django.utils.html import format_html
 
 from kmuhelper import settings, constants
@@ -56,6 +56,22 @@ def kmuhelper_branding(context, module_name=None):
         url_module,
         module.get("title"),
     )
+
+
+@register.inclusion_tag("admin/kmuhelper/_includes/open_kmuhelper_button.html", takes_context=False)
+def kmuhelper_open_kmuhelper_button():
+    """
+    Renders a button to open the KMUHelper app, if the view is available.
+    """
+    try:
+        return {
+            "home_url": reverse("kmuhelper:home"),
+            "show": True
+        }
+    except NoReverseMatch:
+        return {
+            "show": False
+        }
 
 
 @register.inclusion_tag("kmuhelper/_includes/pagechooser.html", takes_context=False)


### PR DESCRIPTION
… prevent the admin from loading if the 'kmuhelper' urls are not available.